### PR TITLE
Make xbmc.Monitor an instance object

### DIFF
--- a/default.py
+++ b/default.py
@@ -15,6 +15,7 @@ class Daemon:
     def __init__(self):
         log("version %s started" % ADDON_VERSION)
         self._init_vars()
+        self.ssis_monitor = xbmc.Monitor()
         self.run_backend()
 
     def _init_vars(self):
@@ -26,7 +27,7 @@ class Daemon:
         self._stop = False
         self.previousitem = ""
         log("starting backend")
-        while (not self._stop) and (not xbmc.Monitor().abortRequested()):
+        while (not self._stop) and (not self.ssis_monitor.abortRequested()):
             if xbmc.getCondVisibility("[Window.IsActive(videoosd) + Skin.String(SkinInfo.AutoCloseVideoOSD)] | [Window.IsActive(musicosd) + Skin.String(SkinInfo.AutoCloseMusicOSD)]"):
                 if xbmc.getCondVisibility("Window.IsActive(videoosd)"):
                     seconds = xbmc.getInfoLabel("Skin.String(SkinInfo.AutoCloseVideoOSD)")


### PR DESCRIPTION
I have a problem of script.skin.info.service not stopping when Kodi exits.  The cause is a work-around in my skin due to startup.xml not being loaded during a profile change where the new profile has my skin active.  My work around was to start the script again on first loading of home.xml.  The script runs OK that way -- second run (if skin run from masterprofile)  immediately quits as it should.  But the first instance (still running) has to be killed when Kodi exists.  In analyzing why it seems that the problem is xbmc.Monitor().abortRequested() isn't getting received.  I think this is due to the backend in the script running as an instance of Daemon class.  So what I did was in the Daemon constructor added an instance object  of self.ssis_monitor for the xbmc.Monitor() class object, that way self.ssis_monitor can properly be linked with self.ssis_monitor.abortRequested() if more than one Daemon objects get created.